### PR TITLE
Added player and rod movement

### DIFF
--- a/src/player.rs
+++ b/src/player.rs
@@ -14,15 +14,15 @@ impl Plugin for PlayerMovementPlugin {
 fn player_movement(
     time: Res<Time>,
     keyboard_input: Res<Input<KeyCode>>,
-    mut sprite_position: Query<&mut Transform, With<Player>>,
+    mut player_position: Query<&mut Transform, With<Player>>,
 ) {
-    for mut transform in &mut sprite_position {
-        if keyboard_input.pressed(KeyCode::Left) {
-            transform.translation.x -= 150. * time.delta_seconds();
-        }
-        if keyboard_input.pressed(KeyCode::Right) {
-            transform.translation.x += 150. * time.delta_seconds();
-        }
+    let mut transform = player_position.single_mut();
+
+    if keyboard_input.pressed(KeyCode::Left) {
+        transform.translation.x -= 150. * time.delta_seconds();
+    }
+    if keyboard_input.pressed(KeyCode::Right) {
+        transform.translation.x += 150. * time.delta_seconds();
     }
 }
 


### PR DESCRIPTION
- Added `PlayerMovementPlugin` 
    - Player can move left and right. 
    - Player and press "Down" to cast rod.
- Added `RodPlugin` 
    - Rod can move up with spacebar. 
    - Rod constantly moves down. 
    - Rod despawns on collision with player.