### PR TITLE
Added player movement and rod

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,27 +1,29 @@
 use bevy::prelude::*;
+use player::{Player, PlayerMovementPlugin};
+use rod::RodPlugin;
+
+pub mod player;
+pub mod rod;
 
 fn main() {
     App::new()
-        .add_plugins(DefaultPlugins)
+        .add_plugins((DefaultPlugins, PlayerMovementPlugin, RodPlugin))
         .add_systems(Startup, setup)
         .run();
 }
-
 fn setup(mut commands: Commands) {
     commands.spawn(Camera2dBundle::default());
 
-    commands.spawn((TextBundle::from_section(
-        "Gone\nFish!",
-        TextStyle {
-            font_size: 100.0,
+    commands.spawn((
+        Player,
+        SpriteBundle {
+            sprite: Sprite {
+                color: Color::rgb(0.25, 0.25, 0.75),
+                custom_size: Some(Vec2::new(100.0, 50.0)),
+                ..default()
+            },
+            transform: Transform::from_translation(Vec3::new(0.0, 50.0, 0.0)),
             ..default()
         },
-    )
-    .with_text_alignment(TextAlignment::Center)
-    .with_style(Style {
-        position_type: PositionType::Absolute,
-        bottom: Val::Px(5.0),
-        right: Val::Px(5.0),
-        ..default()
-    }),));
+    ));
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,10 +19,13 @@ fn setup(mut commands: Commands) {
         SpriteBundle {
             sprite: Sprite {
                 color: Color::rgb(0.25, 0.25, 0.75),
-                custom_size: Some(Vec2::new(100.0, 50.0)),
                 ..default()
             },
-            transform: Transform::from_translation(Vec3::new(0.0, 50.0, 0.0)),
+            transform: Transform {
+                translation: Vec3::new(0.0, 50.0, 0.0),
+                scale: Vec3::new(100.0, 50.0, 0.0),
+                ..default()
+            },
             ..default()
         },
     ));

--- a/src/player.rs
+++ b/src/player.rs
@@ -14,14 +14,26 @@ impl Plugin for PlayerMovementPlugin {
 fn player_movement(
     time: Res<Time>,
     keyboard_input: Res<Input<KeyCode>>,
+    window: Query<&mut Window>,
     mut player_position: Query<&mut Transform, With<Player>>,
 ) {
     let mut transform = player_position.single_mut();
+    let window = window.single();
 
-    if keyboard_input.pressed(KeyCode::Left) {
-        transform.translation.x -= 150. * time.delta_seconds();
+    // From center of screen.
+    let window_width = window.resolution.width() / 2.;
+    // From center of player.
+    let player_width = transform.scale.truncate().x / 2.;
+
+    if (transform.translation.x - player_width) + 1. > -window_width {
+        if keyboard_input.pressed(KeyCode::Left) {
+            transform.translation.x -= 150. * time.delta_seconds();
+        }
     }
-    if keyboard_input.pressed(KeyCode::Right) {
-        transform.translation.x += 150. * time.delta_seconds();
+
+    if (transform.translation.x + player_width) + 1. < window_width {
+        if keyboard_input.pressed(KeyCode::Right) {
+            transform.translation.x += 150. * time.delta_seconds();
+        }
     }
 }

--- a/src/player.rs
+++ b/src/player.rs
@@ -1,0 +1,27 @@
+use bevy::prelude::*;
+
+#[derive(Component)]
+pub struct Player;
+
+pub struct PlayerMovementPlugin;
+
+impl Plugin for PlayerMovementPlugin {
+    fn build(&self, app: &mut App) {
+        app.add_systems(Update, player_movement);
+    }
+}
+
+fn player_movement(
+    time: Res<Time>,
+    keyboard_input: Res<Input<KeyCode>>,
+    mut player_position: Query<&mut Transform, With<Player>>,
+) {
+    let mut transform = player_position.single_mut();
+
+    if keyboard_input.pressed(KeyCode::Left) {
+        transform.translation.x -= 150. * time.delta_seconds();
+    }
+    if keyboard_input.pressed(KeyCode::Right) {
+        transform.translation.x += 150. * time.delta_seconds();
+    }
+}

--- a/src/player.rs
+++ b/src/player.rs
@@ -25,13 +25,13 @@ fn player_movement(
     // From center of player.
     let player_width = transform.scale.truncate().x / 2.;
 
-    if (transform.translation.x - player_width) + 1. > -window_width {
+    if transform.translation.x - player_width > -window_width {
         if keyboard_input.pressed(KeyCode::Left) {
             transform.translation.x -= 150. * time.delta_seconds();
         }
     }
 
-    if (transform.translation.x + player_width) + 1. < window_width {
+    if transform.translation.x + player_width < window_width {
         if keyboard_input.pressed(KeyCode::Right) {
             transform.translation.x += 150. * time.delta_seconds();
         }

--- a/src/rod.rs
+++ b/src/rod.rs
@@ -1,0 +1,98 @@
+use crate::player::Player;
+use bevy::{prelude::*, sprite::collide_aabb::collide};
+
+#[derive(Event, Default)]
+struct CollisionEvent;
+
+#[derive(Component)]
+pub struct Rod;
+
+pub struct RodPlugin;
+
+impl Plugin for RodPlugin {
+    fn build(&self, app: &mut App) {
+        app.add_event::<CollisionEvent>()
+            .add_systems(Update, (cast_rod, rod_movement, check_for_collisions));
+    }
+}
+
+const ROD_LENGTH: f32 = 200.0;
+const ROD_MOVEMENT_UP: f32 = 20.0;
+
+fn cast_rod(
+    mut commands: Commands,
+    keyboard_input: Res<Input<KeyCode>>,
+    rod: Query<&Rod>,
+    player_position: Query<&Transform, With<Player>>,
+) {
+    let player = player_position.single();
+
+    // Only spawn a new rod if there isn't already one spawned
+    if let Ok(_) = rod.get_single() {
+        return;
+    }
+
+    if keyboard_input.just_pressed(KeyCode::Down) {
+        commands.spawn((
+            Rod,
+            SpriteBundle {
+                sprite: Sprite {
+                    color: Color::rgb(0.25, 0.75, 0.25),
+                    custom_size: Some(Vec2::new(40.0, 40.0)),
+                    ..default()
+                },
+                transform: Transform::from_translation(Vec3::new(player.translation.x, -5.0, 0.0)),
+                ..default()
+            },
+        ));
+    }
+}
+
+fn check_for_collisions(
+    mut commands: Commands,
+    rod_position: Query<(Entity, &Transform), (With<Rod>, Without<Player>)>,
+    player_position: Query<&Transform, With<Player>>,
+    mut collision_events: EventWriter<CollisionEvent>,
+) {
+    let player = player_position.single();
+
+    if let Ok((rod_entity, rod)) = rod_position.get_single() {
+        // Despawn rod when it's reeled back in
+        if let Some(_) = collide(
+            player.translation,
+            player.scale.truncate(),
+            rod.translation,
+            rod.scale.truncate(),
+        ) {
+            // Sends a collision event so that other systems can react to the collision
+            collision_events.send_default();
+
+            commands.entity(rod_entity).despawn();
+        }
+    }
+}
+
+fn rod_movement(
+    time: Res<Time>,
+    keyboard_input: Res<Input<KeyCode>>,
+    mut rod_position: Query<&mut Transform, (With<Rod>, Without<Player>)>,
+    player_position: Query<&Transform, With<Player>>,
+) {
+    let player = player_position.single();
+
+    if let Ok(mut transform) = rod_position.get_single_mut() {
+        // Move rod up
+        if keyboard_input.just_pressed(KeyCode::Space) {
+            transform.translation.y += ROD_MOVEMENT_UP;
+        }
+
+        // Keep rod x aligned with player
+        transform.translation.x = player.translation.x;
+
+        // Constantly move the rod downwards as long as it's above
+        // the length of the rod
+        if transform.translation.y > (0.0 - ROD_LENGTH) {
+            transform.translation.y -= 50.0 * time.delta_seconds();
+        }
+    }
+}

--- a/src/rod.rs
+++ b/src/rod.rs
@@ -1,8 +1,15 @@
 use crate::player::Player;
 use bevy::{prelude::*, sprite::collide_aabb::collide};
 
+// We may not need these events but i'll keep them here for now.
 #[derive(Event, Default)]
-struct CollisionEvent;
+struct BoatCollisionEvent;
+
+#[derive(Event, Default)]
+struct FishCollisionEvent;
+
+#[derive(Event, Default)]
+struct TrashCollisionEvent;
 
 #[derive(Component)]
 pub struct Rod;
@@ -11,7 +18,7 @@ pub struct RodPlugin;
 
 impl Plugin for RodPlugin {
     fn build(&self, app: &mut App) {
-        app.add_event::<CollisionEvent>()
+        app.add_event::<BoatCollisionEvent>()
             .add_systems(Update, (cast_rod, rod_movement, check_for_collisions));
     }
 }
@@ -38,10 +45,13 @@ fn cast_rod(
             SpriteBundle {
                 sprite: Sprite {
                     color: Color::rgb(0.25, 0.75, 0.25),
-                    custom_size: Some(Vec2::new(40.0, 40.0)),
                     ..default()
                 },
-                transform: Transform::from_translation(Vec3::new(player.translation.x, -5.0, 0.0)),
+                transform: Transform {
+                    translation: Vec3::new(player.translation.x, -5.0, 0.0),
+                    scale: Vec3::new(40.0, 40.0, 0.0),
+                    ..default()
+                },
                 ..default()
             },
         ));
@@ -52,7 +62,7 @@ fn check_for_collisions(
     mut commands: Commands,
     rod_position: Query<(Entity, &Transform), (With<Rod>, Without<Player>)>,
     player_position: Query<&Transform, With<Player>>,
-    mut collision_events: EventWriter<CollisionEvent>,
+    mut collision_events: EventWriter<BoatCollisionEvent>,
 ) {
     let player = player_position.single();
 


### PR DESCRIPTION
#6 

- Added `PlayerMovementPlugin` 
    - Player can move left and right. 
    - Player and press "Down" to cast rod.
- Added `RodPlugin` 
    - Rod can move up with spacebar. 
    - Rod constantly moves down. 
    - Rod despawns on collision with player.